### PR TITLE
fix: resolve TypeScript build compatibility issues for Vercel deployment

### DIFF
--- a/apps/web/hooks/usePunchSwap.ts
+++ b/apps/web/hooks/usePunchSwap.ts
@@ -89,7 +89,7 @@ export function usePunchSwap(tokenInAddress?: Address) {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [currentQuote, setCurrentQuote] = useState<PunchSwapQuote | null>(null);
-  const quoteIntervalRef = useRef<NodeJS.Timeout | null>(null);
+  const quoteIntervalRef = useRef<number | null>(null);
   const { addNotification } = useUI();
 
   // Get allowance for the input token to PunchSwap Router

--- a/apps/web/hooks/useSushiSwap.ts
+++ b/apps/web/hooks/useSushiSwap.ts
@@ -45,7 +45,7 @@ export function useSushiSwap(tokenInAddress?: Address) {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [currentQuote, setCurrentQuote] = useState<SwapQuote | null>(null);
-  const quoteIntervalRef = useRef<NodeJS.Timeout | null>(null);
+  const quoteIntervalRef = useRef<number | null>(null);
 
   // Get allowance for the input token to SushiSwap RouteProcessor
   const {

--- a/apps/web/hooks/useTokenAllowance.ts
+++ b/apps/web/hooks/useTokenAllowance.ts
@@ -118,7 +118,7 @@ export function useTokenAllowance(tokenAddress: Address, spenderAddress?: Addres
 
   // Poll allowance while approval is pending
   useEffect(() => {
-    let interval: NodeJS.Timeout;
+    let interval: number;
     
     if (isApproving && !isApprovalSuccess) {
       // Poll every 3 seconds while approval is pending


### PR DESCRIPTION
## Summary

Resolves TypeScript build failures preventing Vercel deployment for mobile controls testing.

## Changes Made

** Fixed NodeJS.Timeout Type Compatibility Issues:**
- `apps/web/hooks/usePunchSwap.ts:92` - Changed timer ref type from NodeJS.Timeout to number
- `apps/web/hooks/useSushiSwap.ts:48` - Changed timer ref type from NodeJS.Timeout to number
- `apps/web/hooks/useTokenAllowance.ts:121` - Changed timer variable type from NodeJS.Timeout to number

## Why These Changes Resolve Build Errors

In browser/Vercel environments, `setInterval()` returns a `number`, not `NodeJS.Timeout`. The Node.js-specific type was causing TypeScript compilation failures during Vercel deployment.

** Affected Functionality:**
- Live quote updates for PunchSwap DEX integration
- Live quote updates for SushiSwap DEX integration
- Token allowance polling during approval transactions

## Testing Steps for Mobile Controls

1. **Verfiy Build Success:**
   - Confirm Vercel deployment completes without TypeScript errors
   - Check that all hook imports resolve correctly

2. **Test Swap Functionality:**
   - Test PunchSwap quote updates on Flow network
   - Test SushiSwap quote updates on Katana network
   - Verify timer intervals work correctly for live quotes

3. **Test Token Approvals:**
   - Test token approval flow with polling
   - Verify allowance updates refresh properly

4. **Mobile Controls Testing:**
   - Test mobile game interface loads correctly
   - Verify touch controls and mobile UI elements
   - Test DeFi interactions on mobile devices

## Files Changed
- `apps/web/hooks/usePunchSwap.ts`
- `apps/web/hooks/useSushiSwap.ts`
- `apps/web/hooks/useTokenAllowance.ts`

Closes #22